### PR TITLE
Fix devcontainer build issue

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -48,6 +48,10 @@ jobs:
             type=ref,event=pr
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Transform tags to comma-separated list
+        id: transform-tags
+        run: echo "tags=$(echo ${{ steps.meta.outputs.tags }} | tr '\n' ',')" >> $GITHUB_ENV
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -62,4 +66,4 @@ jobs:
           imageName: ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}
           push: always
           platform: linux/amd64,linux/arm64
-          imageTag: ${{ steps.meta.outputs.tags }}
+          imageTag: ${{ env.tags }}


### PR DESCRIPTION
Fixes #4

Fix devcontainer build issue by transforming image tags to a comma-separated list.

* Add a step to transform `steps.meta.outputs.tags` to a comma-separated list in `.github/workflows/build-and-push.yml`.
* Use the transformed output in the `imageTag` parameter of the `Build and push devcontainer image` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/makeitstrict/devcontainer/pull/5?shareId=e7ba9c6e-cd51-45b3-bb3a-176b70ee12a9).